### PR TITLE
Skip blank lines in procfile

### DIFF
--- a/lib/procfile.js
+++ b/lib/procfile.js
@@ -43,6 +43,7 @@ procfile.parse = function (lines) {
   var procs = {};
   
   lines.split('\n').forEach(function (line) {
+    if (line === '') return;
     var parts   = line.split(':'),
         details = parts[1].trim().split(' '),
         name    = parts[0];

--- a/test/fixtures/newline.procfile
+++ b/test/fixtures/newline.procfile
@@ -1,0 +1,2 @@
+web: node myapp.js -p 80 --some-option
+worker: node myworker.js --other-option

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -10,7 +10,7 @@ var fs = require('fs'),
     path = require('path');
 
 var fixtures = path.join(__dirname, 'fixtures'),
-    files = [path.join(fixtures, 'ruby.procfile'), path.join(fixtures, 'node.procfile')],
+    files = [path.join(fixtures, 'ruby.procfile'), path.join(fixtures, 'node.procfile'), path.join(fixtures, 'newline.procfile')],
     procfiles = {};
 
 var helpers = exports;

--- a/test/procfile-test.js
+++ b/test/procfile-test.js
@@ -42,6 +42,11 @@ vows.describe('procfile').addBatch({
         });
         
         helpers.putParsed('node', procs);
+      },
+      "with newline at end of file": function() {
+        assert.doesNotThrow(function() {
+          var procs = procfile.parse(procfiles.newline);
+        });
       }
     }
   }


### PR DESCRIPTION
I was getting an error parsing procfiles that had a newline at EOF. This skips blank lines in the procfile without processing them.
