### PR TITLE
Handle commands containing colons

### DIFF
--- a/lib/procfile.js
+++ b/lib/procfile.js
@@ -44,9 +44,9 @@ procfile.parse = function (lines) {
   
   lines.split('\n').forEach(function (line) {
     if (line === '') return;
-    var parts   = line.split(':'),
-        details = parts[1].trim().split(' '),
-        name    = parts[0];
+    var parts   = line.match(/^([A-Za-z0-9_]+):\s*(.+)$/),
+        details = parts[2].trim().split(' '),
+        name    = parts[1];
     
     procs[name] = {
       command: details[0],

--- a/test/procfile-test.js
+++ b/test/procfile-test.js
@@ -47,6 +47,10 @@ vows.describe('procfile').addBatch({
         assert.doesNotThrow(function() {
           var procs = procfile.parse(procfiles.newline);
         });
+      },
+      "with colons in the command": function() {
+        var procs = procfile.parse('worker: node worker.js queue:work');
+        assert.deepEqual(procs.worker.options, ['worker.js', 'queue:work']);
       }
     }
   }


### PR DESCRIPTION
Hello again!

I've updated the parser to use the [recommended Procfile regex](https://github.com/ddollar/foreman/blob/68f098c1d23bc68713849f79a1c29297ecb2a712/lib/foreman/procfile.rb#L5-L7) as I was having issues with commands that contained colons.
